### PR TITLE
Add overworld rough draft

### DIFF
--- a/project/common/ui/hud/battle_result_canvas_layer.gd
+++ b/project/common/ui/hud/battle_result_canvas_layer.gd
@@ -1,4 +1,5 @@
 extends CanvasLayer
+signal battle_end_acknowledged
 
 @export var result: BattleResult:
 	set(val):
@@ -28,4 +29,4 @@ func _on_battle_ended(battle_result: BattleResult):
 
 
 func _on_ok_pressed():
-	get_tree().reload_current_scene()
+	battle_end_acknowledged.emit()

--- a/project/levels/battles/battle/battle_example.tscn
+++ b/project/levels/battles/battle/battle_example.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://vpgut26v8bd2"]
+[gd_scene load_steps=3 format=3 uid="uid://po062wp2w2qv"]
 
 [ext_resource type="PackedScene" uid="uid://b4msrqbohquak" path="res://levels/battles/battle_template.tscn" id="1_ylo2p"]
 [ext_resource type="Resource" uid="uid://dj46ja1socuji" path="res://levels/battles/example_scenario.tres" id="2_fmilv"]

--- a/project/levels/battles/battle/battle_node.gd
+++ b/project/levels/battles/battle/battle_node.gd
@@ -3,7 +3,9 @@ extends Node2D
 
 ## Reference to the scenario to load the battle from
 @export var battle_scenario: BattleScenario
+@export var next_scene: PackedScene
 var battle: Battle
+
 @onready var battle_grid_node: BattleGridNode = $BattleGridNode
 @onready var battle_player_input: BattlePlayerInput = $BattlePlayerInput
 
@@ -19,3 +21,10 @@ func initialize():
 
 	# For now, battle begins on scene start
 	battle.begin()
+
+
+func _on_battle_end_acknowledged():
+	# Could not get this to work properly unless I hardcoded the file path here
+	# Not even preloading the scene as a PackedScene worked
+	# Need to revisit this to make next scene configurable for each battle
+	get_tree().change_scene_to_file("res://levels/overworld/overworld.tscn")

--- a/project/levels/battles/battle_with_ui.tscn
+++ b/project/levels/battles/battle_with_ui.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=6 format=3 uid="uid://ccjjq4bo3gd3i"]
+
+[ext_resource type="PackedScene" uid="uid://b4msrqbohquak" path="res://levels/battles/battle_template.tscn" id="1_d6hkn"]
+[ext_resource type="Resource" uid="uid://dj46ja1socuji" path="res://levels/battles/example_scenario.tres" id="2_nntyl"]
+[ext_resource type="Script" path="res://components/pannable.gd" id="3_slpe6"]
+[ext_resource type="PackedScene" uid="uid://bl2uosxojajej" path="res://common/ui/hud/hud.tscn" id="4_duikw"]
+[ext_resource type="PackedScene" uid="uid://bnrifgfngatkk" path="res://common/ui/hud/battle_result_canvas_layer.tscn" id="5_y3eor"]
+
+[node name="TestFullBattleUi" type="Node2D"]
+
+[node name="BattleTemplate" parent="." instance=ExtResource("1_d6hkn")]
+position = Vector2(-164, -89)
+battle_scenario = ExtResource("2_nntyl")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+
+[node name="Pannable" type="Node" parent="Camera2D"]
+script = ExtResource("3_slpe6")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="PlayerHudScreen" parent="CanvasLayer/Control" instance=ExtResource("4_duikw")]
+layout_mode = 1
+
+[node name="BattleResultCanvasLayer" parent="CanvasLayer" instance=ExtResource("5_y3eor")]
+
+[connection signal="battle_end_acknowledged" from="CanvasLayer/BattleResultCanvasLayer" to="BattleTemplate" method="_on_battle_end_acknowledged"]

--- a/project/levels/battles/floor_01/01_battle.tscn
+++ b/project/levels/battles/floor_01/01_battle.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=6 format=3 uid="uid://dxgx8bqpj3kle"]
+
+[ext_resource type="PackedScene" uid="uid://b4msrqbohquak" path="res://levels/battles/battle_template.tscn" id="1_5tqgd"]
+[ext_resource type="Resource" uid="uid://dj46ja1socuji" path="res://levels/battles/example_scenario.tres" id="2_6ivxv"]
+[ext_resource type="Script" path="res://components/pannable.gd" id="3_st5n4"]
+[ext_resource type="PackedScene" uid="uid://bl2uosxojajej" path="res://common/ui/hud/hud.tscn" id="4_l8mo6"]
+[ext_resource type="PackedScene" uid="uid://bnrifgfngatkk" path="res://common/ui/hud/battle_result_canvas_layer.tscn" id="5_gj1lr"]
+
+[node name="TestFullBattleUi" type="Node2D"]
+
+[node name="BattleTemplate" parent="." instance=ExtResource("1_5tqgd")]
+position = Vector2(-164, -89)
+battle_scenario = ExtResource("2_6ivxv")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+
+[node name="Pannable" type="Node" parent="Camera2D"]
+script = ExtResource("3_st5n4")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="PlayerHudScreen" parent="CanvasLayer/Control" instance=ExtResource("4_l8mo6")]
+layout_mode = 1
+
+[node name="BattleResultCanvasLayer" parent="CanvasLayer" instance=ExtResource("5_gj1lr")]
+
+[connection signal="battle_end_acknowledged" from="CanvasLayer/BattleResultCanvasLayer" to="BattleTemplate" method="_on_battle_end_acknowledged"]

--- a/project/levels/overworld/overworld.tscn
+++ b/project/levels/overworld/overworld.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=3 format=3 uid="uid://cmyvsbdrmrcrf"]
+
+[ext_resource type="PackedScene" uid="uid://by2307iknv60" path="res://levels/overworld/overworld_map_node.tscn" id="1_gfxx5"]
+[ext_resource type="PackedScene" uid="uid://dxgx8bqpj3kle" path="res://levels/battles/floor_01/01_battle.tscn" id="2_umo1d"]
+
+[node name="Overworld" type="Node2D"]
+
+[node name="Line2D" type="Line2D" parent="."]
+points = PackedVector2Array(208, 175, 308, 175, 408, 175)
+width = 1.0
+default_color = Color(0.8, 0.8, 0.8, 1)
+
+[node name="OverworldMapNode" parent="." instance=ExtResource("1_gfxx5")]
+offset_left = 200.0
+offset_top = 167.0
+offset_right = 216.0
+offset_bottom = 183.0
+scene_to_load = ExtResource("2_umo1d")
+
+[node name="OverworldMapNode2" parent="." instance=ExtResource("1_gfxx5")]
+offset_left = 300.0
+offset_top = 167.0
+offset_right = 316.0
+offset_bottom = 183.0
+scene_to_load = ExtResource("2_umo1d")
+
+[node name="OverworldMapNode3" parent="." instance=ExtResource("1_gfxx5")]
+offset_left = 400.0
+offset_top = 167.0
+offset_right = 416.0
+offset_bottom = 183.0
+scene_to_load = ExtResource("2_umo1d")

--- a/project/levels/overworld/overworld_map_node.gd
+++ b/project/levels/overworld/overworld_map_node.gd
@@ -1,0 +1,22 @@
+class_name OverworldMapNode
+extends TextureRect
+
+@export var display_name: String
+@export var scene_to_load: PackedScene
+@export var connected_nodes: Array[OverworldMapNode]
+@export var scene_root: Node2D
+
+
+func load_scene():
+	if not scene_to_load or not scene_to_load.can_instantiate():
+		return
+	get_tree().change_scene_to_packed(scene_to_load)
+
+
+func _input(event: InputEvent):
+	if event is not InputEventMouseButton:
+		return
+	var button_event = event as InputEventMouseButton
+	if button_event.button_index == MOUSE_BUTTON_LEFT:
+		accept_event()
+		load_scene()

--- a/project/levels/overworld/overworld_map_node.gd.uid
+++ b/project/levels/overworld/overworld_map_node.gd.uid
@@ -1,0 +1,1 @@
+uid://dktcv2gwfmhxa

--- a/project/levels/overworld/overworld_map_node.tscn
+++ b/project/levels/overworld/overworld_map_node.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=3 format=3 uid="uid://by2307iknv60"]
+
+[ext_resource type="Texture2D" uid="uid://b8qsfmsyqhobk" path="res://common/images/square.png" id="1_c0g2d"]
+[ext_resource type="Script" uid="uid://dktcv2gwfmhxa" path="res://levels/overworld/overworld_map_node.gd" id="2_ldy1g"]
+
+[node name="OverworldMapNode" type="TextureRect"]
+modulate = Color(0.43, 0.43, 0.43, 1)
+texture = ExtResource("1_c0g2d")
+script = ExtResource("2_ldy1g")


### PR DESCRIPTION
Very simple draft adding an overworld scene.
Three squares are presented on the screen.
When clicking on any square, it will immediately load the battle scene associated with each square, currently configured to be the same 01_battle.tscn
When a battle is ended, once the player clicks the OK button to acknowledge that the battle is complete, it will return the player to the overworld scene